### PR TITLE
Remove provider so it can be inherited

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -6,8 +6,3 @@ terraform {
     }
   }
 }
-
-provider "aws" {
-  version = "~> 3.12.0"
-  region  = var.region
-}


### PR DESCRIPTION
This allows the caller of the module to declare their own provider.
This can be done either Implicitly by creating a compatible provider in the calling terraform or explicitly though the providers argument in the module declaration.

This addresses issue #18.