### PR TITLE
Remove hardcoded personal accounts and switch to branch based test flow

### DIFF
--- a/.github/workflows/terraform-tests.yml
+++ b/.github/workflows/terraform-tests.yml
@@ -40,7 +40,7 @@ jobs:
       AWS_DEFAULT_REGION: eu-west-1
     name: "Tests"
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'pull_request' && github.base_ref == 'main' && (github.actor == 'samueldumont' || github.actor == 'nicogelders')}}
+    if: ${{ github.event_name == 'pull_request' && github.base_ref == 'main' && github.head_ref == 'open-pr-here' }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@master


### PR DESCRIPTION
I believe this should make the flow more maintainable & straightforward and still not enable anybody from public to launch the test cases